### PR TITLE
Assures two digits for minutes in runTime

### DIFF
--- a/client/src/Components/Response.jsx
+++ b/client/src/Components/Response.jsx
@@ -9,7 +9,7 @@ const Response = ( { title, overview, releaseDate, runTime, top10Cast } ) => {
   if ( runTime !== '' ) { // so runTime ~~~ 160
     hr = Math.floor( runTime / 60 );
     colon = ':';
-    min = runTime % 60;
+    min = ( ( runTime % 60 ) + '0' ).slice( 0, 2 );
   }
   return (
     <div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/51928503/103305977-0b829880-49d2-11eb-9aab-1e4526bf0616.png)
1:00
or
1:10

before 0 were omitted and looked like
1:
or
1:1